### PR TITLE
Fix FastAPI typo in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,17 @@
+from fastapi import *
+from fastapi.responses import FileResponse
+app=FastAPI()
+
+# Static Pages (Never Modify Code in this Block)
+@app.get("/", include_in_schema=False)
+async def index(request: Request):
+	return FileResponse("./static/index.html", media_type="text/html")
+@app.get("/attraction/{id}", include_in_schema=False)
+async def attraction(request: Request, id: int):
+	return FileResponse("./static/attraction.html", media_type="text/html")
+@app.get("/booking", include_in_schema=False)
+async def booking(request: Request):
+	return FileResponse("./static/booking.html", media_type="text/html")
+@app.get("/thankyou", include_in_schema=False)
+async def thankyou(request: Request):
+	return FileResponse("./static/thankyou.html", media_type="text/html")


### PR DESCRIPTION
Fixed a typo in app.py line 3, changing fastapi() to FastAPI()